### PR TITLE
Fix missing syntax error for passing a Str as a keyword argument name.

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1560,6 +1560,10 @@ bool argument(State & s, AstExpr & ast) {
         AstKeywordPtr ptr;
         location(s, create(ptr));
         ast = ptr;
+        if (first->type != AstType::Name) {
+          syntax_error(s, ast, "Expected identifier before `=` in keyword argument");
+          return false;
+        }
         ptr->name = first;
         if(!test(s, ptr->value)) {
             syntax_error(s, ast, "Expected expression after `=`");


### PR DESCRIPTION
Previously, the following would not produce a syntax error:
```my_func('a'=1234)```

I believe this bug is because the python grammar file allows for this type of behaviour but the python parser itself disallows it, and libpypa didn't include the behaviour from the python parser, only the grammar file. 