### PR TITLE
Prevent users from assigning to True, False, None nodes

### DIFF
--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1766,7 +1766,13 @@ bool expr_stmt(State & s, AstStmt & ast) {
         AstBinOpType op{};
         if(augassign(s, op)) {
             switch(target->type) {
-            case AstType::Name:
+            case AstType::Name: {
+                auto name = std::static_pointer_cast<AstName>(target);
+                if (disallowed_names.find(name->id) != disallowed_names.end()) {
+                    syntax_error(s, target, std::string(absl::Substitute("can't assign to $0", name->id)).c_str());
+                    return false;
+                }
+            }
             case AstType::Attribute:
             case AstType::Subscript:
                 break;

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -1772,6 +1772,7 @@ bool expr_stmt(State & s, AstStmt & ast) {
                     syntax_error(s, target, std::string(absl::Substitute("can't assign to $0", name->id)).c_str());
                     return false;
                 }
+                break;
             }
             case AstType::Attribute:
             case AstType::Subscript:
@@ -1831,6 +1832,7 @@ bool expr_stmt(State & s, AstStmt & ast) {
                             syntax_error(s, target, std::string(absl::Substitute("can't assign to $0", name->id)).c_str());
                             return false;
                         }
+                        break;
                     }
                     case AstType::Attribute:
                     case AstType::Subscript:

--- a/src/pypa/parser/parser.cc
+++ b/src/pypa/parser/parser.cc
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <unordered_set>
 
 // NOTE(zasgar) Disabling GMP.
 //#include <gmp.h>
@@ -24,6 +25,7 @@
 #include <pypa/ast/context_assign.hh>
 
 #include "absl/strings/numbers.h"
+#include "absl/strings/substitute.h"
 
 namespace pypa {
 
@@ -1752,6 +1754,7 @@ bool funcdef(State & s, AstStmt & ast) {
     return guard.commit();
 }
 
+static std::unordered_set<std::string> disallowed_names{"True", "False", "None"};
 bool expr_stmt(State & s, AstStmt & ast) {
     StateGuard guard(s);
     AstExpressionStatementPtr ptr;
@@ -1816,7 +1819,13 @@ bool expr_stmt(State & s, AstStmt & ast) {
                     case AstType::ListComp:
                         syntax_error(s, target, "can't assign to list comprehension");
                         return false;
-                    case AstType::Name:
+                    case AstType::Name: {
+                        auto name = std::static_pointer_cast<AstName>(target);
+                        if (disallowed_names.find(name->id) != disallowed_names.end()) {
+                            syntax_error(s, target, std::string(absl::Substitute("can't assign to $0", name->id)).c_str());
+                            return false;
+                        }
+                    }
                     case AstType::Attribute:
                     case AstType::Subscript:
                     case AstType::List:


### PR DESCRIPTION
Python doesn't allow assignments to literals
```
# Literal patterns are used for equality and identity constraints
literal_pattern:
    | signed_number !('+' | '-') 
    | complex_number 
    | strings 
    | 'None' 
    | 'True' 
    | 'False' 
```
but libpypa doesn't cover the last items. As a quick patch, we check the set of reserved keywords (None,True,False) and if it matches we reject those commits.

Test Plan: Patched this change into the main Pixie repo and checked to make sure you couldn't run the following scripts:
```
True = 1
False = 1
None = 1
```
Signed-off-by: Phillip Kuznetsov <pkuznetsov@pixielabs.ai>